### PR TITLE
Fixes blog sorting to CreateDate; updates indexes

### DIFF
--- a/API/ThriveChurchOfficialAPI/ThriveChurchOfficialAPI.Repositories/Constants/IndexKeys.cs
+++ b/API/ThriveChurchOfficialAPI/ThriveChurchOfficialAPI.Repositories/Constants/IndexKeys.cs
@@ -25,7 +25,7 @@ namespace ThriveChurchOfficialAPI.Repositories
         // Blogs Collection
         public const string BlogsBySlugAsc_Unique = "Blogs_Slug_1";
         public const string BlogsByIsPublishedAsc = "Blogs_IsPublished_1";
-        public const string BlogsByPublishedDateDesc = "Blogs_PublishedDate_-1";
-        public const string BlogsByIsPublishedAndPublishedDate = "Blogs_IsPublished_1_PublishedDate_-1";
+        public const string BlogsByCreateDateDesc = "Blogs_CreateDate_-1";
+        public const string BlogsByIsPublishedAndCreateDate = "Blogs_IsPublished_1_CreateDate_-1";
     }
 }

--- a/API/ThriveChurchOfficialAPI/ThriveChurchOfficialAPI.Repositories/Repos/BlogRepository.cs
+++ b/API/ThriveChurchOfficialAPI/ThriveChurchOfficialAPI.Repositories/Repos/BlogRepository.cs
@@ -58,17 +58,17 @@ namespace ThriveChurchOfficialAPI.Repositories
                     Builders<BlogPost>.IndexKeys.Ascending(b => b.IsPublished),
                     new CreateIndexOptions { Name = IndexKeys.BlogsByIsPublishedAsc }),
 
-                // Index on PublishedDate for sorting
+                // Index on CreateDate for sorting
                 new CreateIndexModel<BlogPost>(
-                    Builders<BlogPost>.IndexKeys.Descending(b => b.PublishedDate),
-                    new CreateIndexOptions { Name = IndexKeys.BlogsByPublishedDateDesc }),
+                    Builders<BlogPost>.IndexKeys.Descending(b => b.CreateDate),
+                    new CreateIndexOptions { Name = IndexKeys.BlogsByCreateDateDesc }),
 
                 // Compound index for published posts sorted by date (most common query)
                 new CreateIndexModel<BlogPost>(
                     Builders<BlogPost>.IndexKeys
                         .Ascending(b => b.IsPublished)
-                        .Descending(b => b.PublishedDate),
-                    new CreateIndexOptions { Name = IndexKeys.BlogsByIsPublishedAndPublishedDate })
+                        .Descending(b => b.CreateDate),
+                    new CreateIndexOptions { Name = IndexKeys.BlogsByIsPublishedAndCreateDate })
             };
 
             await _blogsCollection.Indexes.CreateManyAsync(indexModels);
@@ -78,7 +78,7 @@ namespace ThriveChurchOfficialAPI.Repositories
         public async Task<BlogPostPagedResponse> GetPublishedBlogPosts(int pageNumber, int pageSize)
         {
             var filter = Builders<BlogPost>.Filter.Eq(b => b.IsPublished, true);
-            var sort = Builders<BlogPost>.Sort.Descending(b => b.PublishedDate);
+            var sort = Builders<BlogPost>.Sort.Descending(b => b.CreateDate);
 
             var totalCount = await _blogsCollection.CountDocumentsAsync(filter);
             var totalPages = (int)Math.Ceiling((double)totalCount / pageSize);
@@ -131,7 +131,7 @@ namespace ThriveChurchOfficialAPI.Repositories
                 )
             );
 
-            var sort = Builders<BlogPost>.Sort.Descending(b => b.PublishedDate);
+            var sort = Builders<BlogPost>.Sort.Descending(b => b.CreateDate);
             var totalCount = await _blogsCollection.CountDocumentsAsync(filter);
             var totalPages = (int)Math.Ceiling((double)totalCount / pageSize);
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,105 +1,25 @@
-# ThriveChurchOfficialAPI — CLAUDE.md
+# ThriveChurchOfficialAPI
 
-Primary backend for Thrive sermon platform. Manages sermon series datastore, provides public API for sermon distribution, handles authentication and API versioning.
+C#/.NET 8 backend. MongoDB (SermonSeries DB). Single source of truth for all sermon/config data.
 
-## Tech Stack
-
-- **Framework:** C# / .NET (6.0+)
-- **Database:** MongoDB (mongo-thrive-production in prod; mongo-localhost or local instance in dev)
-- **API Versioning:** URL-based (/v1/, /v2/, etc.) — ensures backward compatibility
-- **Testing:** MSTest, Moq, integration tests against MongoDB
-- **Deployment:** GitHub Actions → Docker → AWS (ECS/Lambda)
-
-## Project Structure
-
-```
-ThriveChurchOfficialAPI/
-├── Controllers/          # HTTP endpoints (thin; delegate to services)
-├── Services/             # Business logic (interfaces in Abstract/, implementations in Services/)
-├── Repositories/         # Data access (inherit from RepositoryBase<T>)
-├── Core/                 # Domain models, DTOs, enums
-├── Tests/                # Unit + integration tests (must achieve 100% branch coverage)
-├── Startup.cs            # DI container, middleware
-└── .worktrees/           # Feature branches (local, gitignored)
-```
-
-## Local Development
-
-### 1. MongoDB Setup
-
-```bash
-# Start MongoDB locally
-mongod --dbpath=C:\data\mongodb
-
-# Connection string (appsettings.json in Dev):
-# mongodb://localhost:27017/SermonSeries
-```
-
-### 2. Run the API
+## Commands
 
 ```bash
 dotnet restore
-dotnet run --configuration Debug
-
-# Listens on: https://localhost:5001
-# Swagger available at: https://localhost:5001/swagger
+dotnet run --configuration Debug      # → https://localhost:5001/swagger
+dotnet test --configuration Debug     # 100% branch on Services/ + Core/
 ```
 
-### 3. Run Tests
+MongoDB: `mongod --dbpath=C:\data\mongodb` (local dev, SermonSeries DB)
 
-```bash
-dotnet test --configuration Debug
+## Rules
 
-# Enforce 100% branch coverage on Services/ and Core/
-# Integration tests connect to local MongoDB (auto-seeded from fixtures)
-```
+- N-tier strict: Controllers → Services → Repositories → Core
+- No AutoMapper — manual mapping only
+- Return `SystemResponse<T>` from services
+- Repositories inherit `RepositoryBase<T>`, implement `IRepository<T>`
+- Soft deletes: `IsActive = false`, never physical delete
 
-## Code Patterns
-
-**N-tier architecture (strict):** Controllers → Services → Repositories → Core
-
-**Service pattern:**
-- Accept 3–7 repository/service dependencies via constructor injection
-- Validate request → call repos/services → compose result → return `SystemResponse<T>`
-- Example: `SermonService.GetSeriesByIdAsync(id)` validates, queries repo, formats DTO
-
-**Repository pattern:**
-- Inherit from `RepositoryBase<T>`
-- Implement specific queries (beyond CRUD)
-- Implement `IRepository<T>` interface
-- Example: `SermonSeriesRepository.GetAllWithEpisodesAsync()`
-
-**DTOs:**
-- Separate request/response models
-- Map from domain → DTO in Service layer
-- Use AutoMapper or manual mapping
-
-## Deployment
-
-- **Branch:** `master` → automatic build & deploy to production
-- **CI/CD:** GitHub Actions → Docker build → AWS ECS
-- **Trigger:** Immediate on merge to master (no approval gates)
-- **Rollback:** Revert commit, re-push to master (redeploy triggered automatically)
-- **Monitoring:** CloudWatch logs, X-Ray for request tracing
-
-## Shared Standards & References
-
-For patterns shared across all projects, see the Docs repository:
-
-- **Shared patterns** — `Docs/Shared/`
-  - `N-Tier-Architecture.md` — Service/Repository/DbContext pattern (applied here)
-  - `Testing-Patterns.md` — 100% coverage requirement, test structure
-  - `Git-Workflow.md` — Worktree discipline, commit rules, PR process
-  - `Naming-Conventions.md` — C# naming conventions
-  - `Development-Workflow.md` — Feature implementation order
-
-- **Thrive-specific** — `Docs/Thrive/`
-  - `Architecture-Overview.md` — How all Thrive repos fit together
-  - `Sermon-API.md` — Collections, endpoints, versioning strategy
-
-## Key Principles
-
-- **Single responsibility:** Controllers thin, Services rich, Repositories data-focused
-- **Testability:** All business logic in Services; integration tests hit real MongoDB
-- **Backward compatibility:** Versioning strategy protects legacy clients
-- **TypeScript/Angular consumers:** Sermon data consumed by mobile app (`ThriveChurchOfficialApp_CrossPlatform`) and web clients
+## Docs
+- `Docs/Thrive/Sermon-API.md` — collections, endpoints, versioning
+- `Docs/Shared/N-Tier-Architecture.md` — service/repository patterns

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,105 @@
+# ThriveChurchOfficialAPI — CLAUDE.md
+
+Primary backend for Thrive sermon platform. Manages sermon series datastore, provides public API for sermon distribution, handles authentication and API versioning.
+
+## Tech Stack
+
+- **Framework:** C# / .NET (6.0+)
+- **Database:** MongoDB (mongo-thrive-production in prod; mongo-localhost or local instance in dev)
+- **API Versioning:** URL-based (/v1/, /v2/, etc.) — ensures backward compatibility
+- **Testing:** MSTest, Moq, integration tests against MongoDB
+- **Deployment:** GitHub Actions → Docker → AWS (ECS/Lambda)
+
+## Project Structure
+
+```
+ThriveChurchOfficialAPI/
+├── Controllers/          # HTTP endpoints (thin; delegate to services)
+├── Services/             # Business logic (interfaces in Abstract/, implementations in Services/)
+├── Repositories/         # Data access (inherit from RepositoryBase<T>)
+├── Core/                 # Domain models, DTOs, enums
+├── Tests/                # Unit + integration tests (must achieve 100% branch coverage)
+├── Startup.cs            # DI container, middleware
+└── .worktrees/           # Feature branches (local, gitignored)
+```
+
+## Local Development
+
+### 1. MongoDB Setup
+
+```bash
+# Start MongoDB locally
+mongod --dbpath=C:\data\mongodb
+
+# Connection string (appsettings.json in Dev):
+# mongodb://localhost:27017/SermonSeries
+```
+
+### 2. Run the API
+
+```bash
+dotnet restore
+dotnet run --configuration Debug
+
+# Listens on: https://localhost:5001
+# Swagger available at: https://localhost:5001/swagger
+```
+
+### 3. Run Tests
+
+```bash
+dotnet test --configuration Debug
+
+# Enforce 100% branch coverage on Services/ and Core/
+# Integration tests connect to local MongoDB (auto-seeded from fixtures)
+```
+
+## Code Patterns
+
+**N-tier architecture (strict):** Controllers → Services → Repositories → Core
+
+**Service pattern:**
+- Accept 3–7 repository/service dependencies via constructor injection
+- Validate request → call repos/services → compose result → return `SystemResponse<T>`
+- Example: `SermonService.GetSeriesByIdAsync(id)` validates, queries repo, formats DTO
+
+**Repository pattern:**
+- Inherit from `RepositoryBase<T>`
+- Implement specific queries (beyond CRUD)
+- Implement `IRepository<T>` interface
+- Example: `SermonSeriesRepository.GetAllWithEpisodesAsync()`
+
+**DTOs:**
+- Separate request/response models
+- Map from domain → DTO in Service layer
+- Use AutoMapper or manual mapping
+
+## Deployment
+
+- **Branch:** `master` → automatic build & deploy to production
+- **CI/CD:** GitHub Actions → Docker build → AWS ECS
+- **Trigger:** Immediate on merge to master (no approval gates)
+- **Rollback:** Revert commit, re-push to master (redeploy triggered automatically)
+- **Monitoring:** CloudWatch logs, X-Ray for request tracing
+
+## Shared Standards & References
+
+For patterns shared across all projects, see the Docs repository:
+
+- **Shared patterns** — `Docs/Shared/`
+  - `N-Tier-Architecture.md` — Service/Repository/DbContext pattern (applied here)
+  - `Testing-Patterns.md` — 100% coverage requirement, test structure
+  - `Git-Workflow.md` — Worktree discipline, commit rules, PR process
+  - `Naming-Conventions.md` — C# naming conventions
+  - `Development-Workflow.md` — Feature implementation order
+
+- **Thrive-specific** — `Docs/Thrive/`
+  - `Architecture-Overview.md` — How all Thrive repos fit together
+  - `Sermon-API.md` — Collections, endpoints, versioning strategy
+
+## Key Principles
+
+- **Single responsibility:** Controllers thin, Services rich, Repositories data-focused
+- **Testability:** All business logic in Services; integration tests hit real MongoDB
+- **Backward compatibility:** Versioning strategy protects legacy clients
+- **TypeScript/Angular consumers:** Sermon data consumed by mobile app (`ThriveChurchOfficialApp_CrossPlatform`) and web clients


### PR DESCRIPTION
Summary
- Updates blog post sorting and indexing to use CreateDate rather than PublishedDate for listing and pagination.
- Adds a concise CLAUDE.md with project overview, quickstart, and contributor rules.

Details
- Replaces sort fields from PublishedDate to CreateDate in repository queries for published and filtered blog listings.
- Renames and redefines single-field and compound MongoDB indexes to target CreateDate and IsPublished + CreateDate.
- Introduces CLAUDE.md with local dev commands, architecture rules, and doc pointers.

Impact
- API responses now return published blog posts sorted by newest created first.
- Indexes will be created with new names on startup; no schema changes required.