### PR TITLE
ci: bump deprecated Node-20 actions to Node-24 majors

### DIFF
--- a/.github/workflows/api-tests.yml
+++ b/.github/workflows/api-tests.yml
@@ -36,7 +36,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
         with:
           dotnet-version: '8.0.x'
 
@@ -50,7 +50,7 @@ jobs:
         run: dotnet test --no-build --configuration Release --verbosity normal --logger "trx;LogFileName=test-results.trx"
 
       - name: Upload test results
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         if: always()
         with:
           name: test-results

--- a/.github/workflows/aspnetcore.yml
+++ b/.github/workflows/aspnetcore.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
     - uses: actions/checkout@v6
     - name: Setup .NET
-      uses: actions/setup-dotnet@v4
+      uses: actions/setup-dotnet@v5
       with:
         dotnet-version: 8.0.x
     - name: Restore NuGet Packages

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -35,7 +35,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           role-to-assume: arn:aws:iam::349570132161:role/GitHub_OIDC
           aws-region: ${{ env.AWS_REGION }}


### PR DESCRIPTION
## Summary

GitHub is forcing all Node-20 GitHub Actions onto the Node-24 runtime on **2026-06-16**. This PR proactively bumps each affected action to its **lowest available Node-24 major** to minimise breaking-change risk.

## Bumped

| Action | From | To |
|--------|------|----|
| `actions/setup-dotnet` | v4 (node20) | v5 (node24) |
| `actions/upload-artifact` | v4 (node20) | v6 (node24) |
| `aws-actions/configure-aws-credentials` | v4 (node20) | v6 (node24) |

## Left as-is (already node24)

| Action | Version | Reason |
|--------|---------|--------|
| `aws-actions/amazon-ecr-login` | v2 | Already node24 — no change needed |

## Notes

- `actions/upload-artifact` skipped v5 (also node20) and landed on v6 — the lowest node24 major. v6 has no breaking input changes for this usage (`name`, `path`, `retention-days` all unchanged).
- `aws-actions/configure-aws-credentials` skipped v5 (also node20) and landed on v6. The `role-to-assume` + `aws-region` inputs are unchanged in v6.
- Files changed: `api-tests.yml`, `aspnetcore.yml`, `deploy.yml` — only `uses:` version pins modified, no logic changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)